### PR TITLE
Add Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sprout-jetbrains-editors cookbook
 
+[![Build Status](https://travis-ci.org/pivotal-sprout/sprout-jetbrains-editors.png?branch=master)](https://travis-ci.org/pivotal-sprout/sprout-jetbrains-editors)
+
 Recipes for installing Jetbrains editors on OSX, along with Pivotal's IDE preferences for each editor
 
 ### Recipes


### PR DESCRIPTION
This repository doesn't have a Travis badge because it [doesn't have a Travis build](https://travis-ci.org/pivotal-sprout/sprout-jetbrains-editors). As part of accepting this pull request, can you enable Travis for this repo?
