### PR TITLE
Add Android Studio

### DIFF
--- a/recipes/android_studio.rb
+++ b/recipes/android_studio.rb
@@ -1,0 +1,3 @@
+sprout_homebrew_cask 'android-studio'
+sprout_jetbrains_editors_pivotal_preferences 'androidstudio'
+sprout_jetbrains_editors_update_allowed_jvm_version 'android-studio'

--- a/spec/unit/android_studio_spec.rb
+++ b/spec/unit/android_studio_spec.rb
@@ -1,0 +1,21 @@
+require 'unit/spec_helper'
+require 'pry'
+
+describe 'sprout-jetbrains-editors::android_studio' do
+  let(:runner) { ChefSpec::SoloRunner.new }
+
+  it 'installs android studio' do
+    runner.converge(described_recipe)
+    expect(runner).to install_cask('android-studio')
+  end
+
+  it 'runs the pivotal_ide_prefs install script with the androidstudio option' do
+    runner.converge(described_recipe)
+    expect(runner).to install_preferences('androidstudio')
+  end
+
+  it 'attempts to update the allowed jvm version' do
+    runner.converge(described_recipe)
+    expect(runner).to update_allowed_jvm_version('android-studio')
+  end
+end


### PR DESCRIPTION
pivotal_ide_prefs supports Android Studio, so it just makes sense for us to, as well.

Currently, the ide_prefs symlinks to an incorrect preferences directory, but that will be fixed by [pivotal_ide_prefs PR 23](https://github.com/pivotal/pivotal_ide_prefs/pull/23).
